### PR TITLE
ci: gate GitHub Pages publish behind DEPLOY_PAGES repo variable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,9 @@ concurrency:
 jobs:
     build:
         runs-on: ubuntu-latest
+        # Set the repository variable DEPLOY_PAGES to "true" once GitHub
+        # Pages is enabled (Settings -> Pages -> Source: GitHub Actions).
+        if: vars.DEPLOY_PAGES == 'true'
 
         steps:
             - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -215,8 +215,15 @@ every push to `main`:
 2. Runs `npm test` and `npm run build`
 3. Uploads `dist/` as a Pages artifact and deploys it
 
-To enable it on your fork, go to **Settings → Pages** and set the source to
-**GitHub Actions**. The presentation will be available at
+To enable it on your fork:
+
+1. Go to **Settings → Pages** and set the source to **GitHub Actions**.
+2. Go to **Settings → Secrets and variables → Actions → Variables** and add a
+   repository variable named `DEPLOY_PAGES` with the value `true`.
+
+The workflow only runs once `DEPLOY_PAGES` is set to `true`, so pushes to `main`
+won't fail on forks/clones where Pages hasn't been configured yet. The
+presentation will be available at
 `https://<your-username>.github.io/<your-repo>/`.
 
 ### Deploy to Netlify / Vercel / etc.


### PR DESCRIPTION
## Summary
- Gate the `build` job in `publish.yml` on the repository variable `DEPLOY_PAGES` being `"true"`, mirroring how `python-package-template` gates `publish.yml`/`documentation.yml` on `PUBLISH_TO_PYPI`/`DEPLOY_DOCS`.
- Document the new setup step in the README so forks/clones don't get a failing push-to-`main` workflow before Pages is configured.

## Test plan
- [ ] Confirm the `publish.yml` workflow is skipped when `DEPLOY_PAGES` is unset on a push to `main`.
- [ ] Set the `DEPLOY_PAGES` repository variable to `true` and confirm the workflow runs and deploys as before.