### PR TITLE
docs(github): add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,53 @@
+---
+name: 🐛 Bug Report
+about: Create a report to help us improve
+title: '[BUG]: '
+labels: bug
+assignees: ''
+---
+
+## 📝 Description
+
+A clear and concise description of what the bug is.
+
+## 🚀 Reproduction Steps
+
+Steps to reproduce the behavior:
+
+1. '...'
+2. '...'
+3. '...'
+
+## 💻 Minimal Reproducible Example
+
+Please provide the relevant slide Markdown, HTML, or config snippet that
+demonstrates the issue. Use code blocks for readability:
+
+```markdown
+<!-- Your slide content or config here -->
+```
+
+## 📋 Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## 💥 Actual Behavior / Console Output
+
+If applicable, add the browser console error or build log here **after redacting
+secrets** (API keys, tokens, credentials, private URLs/paths, personal data).
+
+```text
+Paste error output here
+
+```
+
+## 🛠 Environment Information
+
+- **Node.js Version:** (e.g., 20.20.2)
+- **Browser:** (e.g., Chrome 126, Firefox 128, Safari 17)
+- **Operating System:** (e.g., Windows 11, Ubuntu 22.04, macOS)
+- **reveal.js Version:** (see `node_modules/reveal.js/package.json`)
+
+## 📎 Additional Context
+
+Add any other context about the problem here (e.g., screenshots, logs).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: GitHub Community Support
+      url: https://github.com/isaac-cf-wong/presentation-template/discussions
+      about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,42 @@
+---
+name: ✨ Feature Request
+about: Suggest an idea or improvement for this template
+title: '[FEATURE]: '
+labels: enhancement
+assignees: ''
+---
+
+## 🎯 Problem Statement
+
+Is your feature request related to a problem? Please describe.
+
+> _Ex: "I'm always frustrated when I have to manually configure X to achieve
+> Y..."_
+
+## 💡 Proposed Solution
+
+A clear and concise description of what you want to happen. Describe the new
+functionality or the change to existing behavior.
+
+## 💻 Proposed Usage Example
+
+If applicable, show how you would imagine the slide Markdown, HTML, or config
+looking with this new feature:
+
+```markdown
+<!-- How you'd like to use the new feature -->
+```
+
+## 🌈 Use Case & Benefits
+
+Why is this feature important to you and other users? How does it improve the
+template?
+
+## 🔄 Alternatives Considered
+
+A clear and concise description of any alternative solutions or workarounds
+you've considered (e.g., a reveal.js plugin or a custom script).
+
+## ⚠️ Additional Context
+
+Add any other context, screenshots, or links to similar implementations here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+---
+name: 🚀 Pull Request
+about: Submit your changes for review
+---
+
+## 📝 Summary
+
+Briefly describe the changes introduced by this PR. Mention any related issues
+using keywords (e.g., `Closes #123`).
+
+## ✨ Type of Change
+
+- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
+- [ ] ✨ New feature (non-breaking change which adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality
+      to not work as expected)
+- [ ] 📝 Documentation update
+- [ ] 🎨 Refactoring (no functional changes, no API changes)
+
+## 🧪 How Has This Been Tested
+
+Please describe the tests that you ran to verify your changes.
+
+- [ ] **Automated Tests:** `npm test`
+- [ ] **Manual Test:** (Describe steps, e.g., `npm start` and check slide N)
+
+## 🏗️ Checklist
+
+- [ ] My code follows the style guidelines of this project.
+- [ ] I have performed a self-review of my own code.
+- [ ] I have commented my code, particularly in hard-to-understand areas.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] My changes generate no new warnings.
+- [ ] I have added tests that prove my fix is effective or that my feature
+      works.
+
+## 📷 Screenshots (if applicable)
+
+If this is a UI/slide change, add before/after screenshots here.


### PR DESCRIPTION
## Summary
- Add `bug-report.md`, `feature-request.md`, and `config.yml` under `.github/ISSUE_TEMPLATE/`, mirroring `python-package-template`'s issue templates but adapted for this repo's npm/reveal.js/slide-based workflow (no Python-specific fields, environment info covers Node.js/browser/reveal.js instead).
- Add `.github/pull_request_template.md`, mirroring `python-package-template`'s PR template, with the test-plan checklist pointing at `npm test` instead of `pytest`.
- Disable blank issues and point the "get support" contact link at this repo's GitHub Discussions.

## Test plan
- [ ] Open a new issue on GitHub and confirm the "🐛 Bug Report" and "✨ Feature Request" templates appear, and blank issues are not offered.
- [ ] Open a new PR and confirm the template body is pre-filled.