### PR TITLE
chore(license): switch from MIT to BSD 3-Clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,26 @@
-MIT License
+Copyright 2026, Isaac C. F. Wong
 
-Copyright (c) 2025 isaac-cf-wong
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Presentation Template 🎯
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD--3--Clause-yellow.svg)](./LICENSE)
 [![Reveal.js](https://img.shields.io/badge/reveal.js-6.x-orange.svg)](https://revealjs.com/)
 [![CI](https://github.com/isaac-cf-wong/presentation-template/actions/workflows/ci.yml/badge.svg)](https://github.com/isaac-cf-wong/presentation-template/actions/workflows/ci.yml)
 [![Publish](https://github.com/isaac-cf-wong/presentation-template/actions/workflows/publish.yml/badge.svg)](https://isaac-cf-wong.github.io/presentation-template/)
@@ -365,8 +365,8 @@ commit.
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
-for details.
+This project is licensed under the BSD 3-Clause License - see the
+[LICENSE](LICENSE) file for details.
 
 ## 🙏 Acknowledgments
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
         "": {
             "name": "presentation-template",
             "version": "0.1.0",
-            "license": "MIT",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "reveal_external": "^1.3",
                 "reveal.js": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "html"
     ],
     "author": "Isaac C. F. Wong",
-    "license": "MIT",
+    "license": "BSD-3-Clause",
     "engines": {
         "node": ">=14.21.3"
     },


### PR DESCRIPTION
## Summary
- Replace `LICENSE` with the BSD 3-Clause text used by `python-package-template`, updating the copyright line to `Copyright 2026, Isaac C. F. Wong`.
- Update the license badge and the License section in `README.md` from MIT to BSD-3-Clause.
- Update the `license` field in `package.json` and the root package entry in `package-lock.json` from `MIT` to `BSD-3-Clause` (third-party dependency license entries in `package-lock.json` are untouched).
- Note: `pyproject.toml` already declared `"License :: OSI Approved :: BSD License"`, so this also fixes a pre-existing mismatch between that classifier and the actual `LICENSE` file.

## Test plan
- [ ] Confirm GitHub's license detection on the repo shows BSD 3-Clause after merge.
- [ ] `npm install` runs cleanly with the updated `package.json`/`package-lock.json`.